### PR TITLE
Update leaderboard with new validation loss entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ We validate at context length 512, so your reported validation loss should also 
 
 | Name           | Validation Loss | Link | Verification status (leave empty) |
 | :------------- | --------------: | ---: | --------------------------------: |
+| Jorge Vanco | 3.03066 | https://api.wandb.ai/links/jorgev/qa9to62v | |
 | Vilhelm Toivonen | 3.03196| https://api.wandb.ai/links/vilhelm-toivonen-helsinki-university/ey73mx97 | |
 | Herman Brunborg | 3.0781| https://api.wandb.ai/links/brunborg-cs336/igorg097 | Verified |
 | Vegard Skogstad | 3.1354 | https://api.wandb.ai/links/skogstadv-hobbyist/kvi98ktt | |
-| Jorge Vanco | 3.1371| https://api.wandb.ai/links/jorgev/qa9to62v | |
 | Stephen Ge | 3.1460 | https://api.wandb.ai/links/stephenge/cc9sewxe | Verified |
 | Brandon Snider | 3.1658 | https://api.wandb.ai/links/brandon-snider-stanford-university/v8n2t4py | Verified |
 | Joe Li | 3.19406 | [Validation loss curve](images/joe_better_muon.png)


### PR DESCRIPTION
I removed the usage of YaRN to increase the sequence length. I also removed any usage of torch.nn and I use my own triton kernel for flash attention