### PR TITLE
Add Tim Chen's entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Stanford class leaderboard (Spring 2026)
 
 | Name           | Validation Loss | Link | Verification status (leave empty) |
 | :------------- | --------------: | ---: | --------------------------------: |
+| Tim Chen | 3.75 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/runs/s8n70ens/panel/kwlfruabc?nw=nwuserchentimsh|
 | naive baseline |            5.00 |      |                          Verified |
 
 <details markdown="1">


### PR DESCRIPTION
Final Validation Loss: 3.75
Plot: https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/runs/s8n70ens/panel/kwlfruabc?nw=nwuserchentimsh

```

Model Specs
- Vocabulary size: 32000
- Context length: 512
- d_model: 768
- Number of layers: 8
- Number of attention heads: 16
- Feed-forward dimension: 2048
- RoPE theta: 10000.0
Note: I also enabled weight tying. 

Training Specs
- Batch size: 96
- Number of steps: 3800
- Warmup steps: 120
- Cosine steps: 3800
- Max learning rate: 1e-3
- Min learning rate: 1e-4
- Weight decay: 0.1
- Adam beta1: 0.9
- Adam beta2: 0.95
- Adam epsilon: 1e-8

```
