### PR TITLE
Add Javier Nieto's validation loss entry to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Stanford class leaderboard (Spring 2026)
 | :------------- | --------------: | ---: | --------------------------------: |
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
+| Javier Nieto   |          3.37   | https://api.wandb.ai/links/jgnieto-stanford-university/rvnadego | |
 | Tim Chen | 3.75 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/runs/s8n70ens/panel/kwlfruabc?nw=nwuserchentimsh|
 | naive baseline |            5.00 |      |                          Verified |
 


### PR DESCRIPTION
I implemented weight tying, optimized the code so that it compiled with minimal graph breaks, tuned the batch size and lr, and increased the width and depth of the model.

Below are the full details:
```python
batch_size: 128
num_steps: 10000
vocab_size: 32000
context_length: 512
d_model: 768
d_ff: 2048
rope_theta: 10000
num_layers: 16
num_heads: 16
max_norm: 1.0
lr: 0.001
lr_min: 0.0001
adamw_eps: 1e-08
beta1: 0.9
beta2: 0.999
weight_decay: 0.1
gradient_clipping: 1.0
lr_warmup_steps: 600
```