### PR TITLE
Add: leaderboard validation loss

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026)
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
 | Tim Chen | 3.75 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/runs/s8n70ens/panel/kwlfruabc?nw=nwuserchentimsh|
+| Jason Meng | 4.13 | https://wandb.ai/jiemeng-stanford-university/cs336-lm/groups/HW1-leaderboard/workspace/panel/bvvdupso1| |
 | naive baseline |            5.00 |      |                          Verified |
 
 <details markdown="1">


### PR DESCRIPTION
Validation loss: 4.13

Link: https://wandb.ai/jiemeng-stanford-university/cs336-lm/groups/HW1-leaderboard/workspace/panel/bvvdupso1

Details: Weight Tying, Change Embedding Initialization, Residual Projection Scaling.
