### PR TITLE
Update validation loss and links for Tim Chen

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | :------------- | --------------: | ---: | --------------------------------: |
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
+| Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Javier Nieto   |          3.37   | https://api.wandb.ai/links/jgnieto-stanford-university/rvnadego | |
 | Tushar Aggarwal | 3.4046 | [https://api.wandb.ai/links/tushar56/bduabcti](https://api.wandb.ai/links/tushar56/tc7lfg7x) | |
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
-| Tim Chen | 3.75 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/runs/s8n70ens/panel/kwlfruabc?nw=nwuserchentimsh|
 | Jason Meng | 4.13 | https://wandb.ai/jiemeng-stanford-university/cs336-lm/groups/HW1-leaderboard/workspace/panel/bvvdupso1| |
 | naive baseline |            5.00 |      |                          Verified |
 


### PR DESCRIPTION
I updated my previous submission (https://github.com/stanford-cs336/assignment1-basics-leaderboard/pull/104 ). After using torch.compile() and torch.set_float32_matmul_precision("high"), I was able to train the model faster so a total of 18750 steps could be run in 45 minutes. The best validation loss (3.335) occurred at step 18300. Other model specs kept unchanged. 

```
Model Specs
- Vocabulary size: 32000
- Context length: 512
- d_model: 768
- Number of layers: 8
- Number of attention heads: 16
- Feed-forward dimension: 2048
- RoPE theta: 10000.0
Note: I also enabled weight tying, torch.compile(), and used torch.set_float32_matmul_precision("high")

Training Specs
- Batch size: 96
- Number of steps: 18750
- Warmup steps: 500
- Cosine steps: 18750
- Max learning rate: 1e-3
- Min learning rate: 1e-4
- Weight decay: 0.1
- Adam beta1: 0.9
- Adam beta2: 0.95
- Adam epsilon: 1e-8
```