### PR TITLE
Add tdalmia leaderboard submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |
+| Tushar Dalmia | 3.36392 | https://api.wandb.ai/links/tdalmia-stanford-university/xxqbg3y0 | |
 | Javier Nieto   |          3.37   | https://api.wandb.ai/links/jgnieto-stanford-university/rvnadego | |
 | Yufei Liu | 3.402 | https://api.wandb.ai/links/yf6-stanford-university/yus0uve4 | |
 | Tushar Aggarwal | 3.4046 | [https://api.wandb.ai/links/tushar56/bduabcti](https://api.wandb.ai/links/tushar56/tc7lfg7x) | |


### PR DESCRIPTION
Final val loss: 3.36392 

Learning curve: https://api.wandb.ai/links/tdalmia-stanford-university/xxqbg3y0

What I did: 

- Hyperparameter sweep: Learning rate, min learning rate ratio, batch size, weight decay, beta1, beta2, d_model, and num_layers. 
- PyTorch optimizations: torch.compile(model), torch.autocast(dtype=bfloat16), torch.set_float32_matmul_precision("high")
- Vectorized data loading: Replaced for loop with vectorized version 
- Weight tying: implemented, but not enabled since didn't improve val loss 

Adding a leaderboard submission that beats the naive baseline before tonight's deadline. May resubmit if I see improvement. 