### PR TITLE
Add Jiaming Shen's leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Yufei Liu | 3.402 | https://api.wandb.ai/links/yf6-stanford-university/yus0uve4 | |
 | Tushar Aggarwal | 3.4046 | [https://api.wandb.ai/links/tushar56/bduabcti](https://api.wandb.ai/links/tushar56/tc7lfg7x) | |
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
+| Jiaming Shen | 3.4462 | https://api.wandb.ai/links/shenjm-stanford-university/nan5mxa8 | |
 | Jason Meng | 4.13 | https://api.wandb.ai/links/jiemeng-stanford-university/mx5r6f5c| |
 | naive baseline |            5.00 |      |                          Verified |
 


### PR DESCRIPTION
Final validation loss: 3.44626
Link to learning curve: https://api.wandb.ai/links/shenjm-stanford-university/0hf2drq1
To improve performance under the compute budget, I scaled up the model to an 8-layer Transformer with $d_{\text{model}}=768$, $d_{\text{ff}}=2048$, 12 attention heads, context length 512, and vocabulary size 32000. I trained with batch size 96 for around 18000 steps using AdamW with learning rate $3\times 10^{-3}$, cosine decay to $3\times 10^{-4}$, 500 warmup steps, weight decay 0.1, and gradient clipping with max norm 1.0.

Using `torch.compile` and `torch.set_float32_matmul_precision('high')` to accelerate training.