### PR TITLE
Sara Kothari submission - 3.48589

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Yufei Liu | 3.402 | https://api.wandb.ai/links/yf6-stanford-university/yus0uve4 | |
 | Tushar Aggarwal | 3.4046 | [https://api.wandb.ai/links/tushar56/bduabcti](https://api.wandb.ai/links/tushar56/tc7lfg7x) | |
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
+| Sara Kothari | 3.48589 | https://api.wandb.ai/links/sarako-stanford-university/zxh58oa8 
 | Jason Meng | 4.13 | https://api.wandb.ai/links/jiemeng-stanford-university/mx5r6f5c| |
 | naive baseline |            5.00 |      |                          Verified |
 


### PR DESCRIPTION
Final validation loss: 3.48589

Learning curve: https://api.wandb.ai/links/sarako-stanford-university/zxh58oa8	

What I did:
- Compared to the baseline configuration, I increased model depth (4 to 16 layers),
halved the batch size (256 to 128), and tuned the learning rate schedule (peak LR,
warmup, and decay parameters).
- I also used "torch.set_float32_matmul_precision('high')". This led to a 3.5x speedup.
