### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | :------------- | --------------: | ---: | --------------------------------: |
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
-| Iddah Mlauzi | 3.21391 | https://wandb.ai/iddah/CS336-Assignment1/groups/leaderboard/workspace/panel/8lutmzai3?nw=nwuseriddah | |
+| Iddah Mlauzi | 3.21391 | https://api.wandb.ai/links/iddah/1ssym3ru | |
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | :------------- | --------------: | ---: | --------------------------------: |
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
+| Iddah Mlauzi | 3.21391 | https://wandb.ai/iddah/CS336-Assignment1/groups/leaderboard/workspace/panel/8lutmzai3?nw=nwuseriddah | |
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |


### PR DESCRIPTION
- QK-norm, Z-loss, Tan-h logit capping
- Also used Muon with Polar Express for orthogonalization
- 192 batch size, 8 heads, 13 layers, lr 1e-2 (max), and the minimum is 0.1x of that
- All weights in BF16
- Final loss: 3.21391