### PR TITLE
Daniel Lee Leaderboard Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
+| Daniel Lee | 3.2629 | https://api.wandb.ai/links/daniel-lee-ml/esat0gwl | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |
 | Tushar Dalmia | 3.36392 | https://api.wandb.ai/links/tdalmia-stanford-university/xxqbg3y0 | |


### PR DESCRIPTION
Validation Loss: 3.2629

I incorporated the following changes:

hyperparameter tuning:
- d_model=768, num_layers=8, num_heads=12, d_ff=2048
- context_length=512, batch_size=64
- cosine lr_schedule, min_lr=1e-5, warmup_iters=200
- weight_decay=0.01, grad_clip=10.0, eval_interval=1000
- auto-calibrated total_iters from measured step speed

architecture changes:
- weight tying, QK-norm, logit soft-capping

optimizer:
- muon (lr=0.02) for 2D weights + AdamW (lr=3e-4) for 1D
- batched Newton-Schulz, matrices grouped by shape

speed + precision:
- bf16, torch.compile, TF32 for matmul precision