### PR TITLE
Luisa Shimabucoro's entry to the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Andy Dimnaku   |  3.3995         | https://api.wandb.ai/links/dimnaku-stanford-university/ffvj5zy8 | |
 | Yufei Liu | 3.402 | https://api.wandb.ai/links/yf6-stanford-university/yus0uve4 | |
 | Tushar Aggarwal | 3.4046 | [https://api.wandb.ai/links/tushar56/bduabcti](https://api.wandb.ai/links/tushar56/tc7lfg7x) | |
+| Luisa Shimabucoro | 3.406 | https://api.wandb.ai/links/hashimoto-group/jr1f6dga | |
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
 | Jason Meng | 4.13 | https://api.wandb.ai/links/jiemeng-stanford-university/mx5r6f5c| |
 | naive baseline |            5.00 |      |                          Verified |


### PR DESCRIPTION
Changes:
- Increased sequence length to 512
- Used Muon (with AdamW non hidden weights)
- Increased learning rate
- Increased d_model and number of layers
- Reduced precision to bf16

https://api.wandb.ai/links/hashimoto-group/jr1f6dga