### PR TITLE
Add Asanshay Gupta's entry to the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Yufei Liu | 3.402 | https://api.wandb.ai/links/yf6-stanford-university/yus0uve4 | |
 | Luisa Shimabucoro | 3.406 | https://api.wandb.ai/links/hashimoto-group/jr1f6dga | |
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
+| Asanshay Gupta        |          3.4451 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
 | Jiaming Shen | 3.4462 | https://api.wandb.ai/links/shenjm-stanford-university/nan5mxa8 | |
 | Sara Kothari | 3.48589 | https://api.wandb.ai/links/sarako-stanford-university/zxh58oa8 | |
 | Subha Vadlamannati | 3.58 | https://api.wandb.ai/links/subhavee2/5t7klnea |


### PR DESCRIPTION
https://api.wandb.ai/links/asanshay-stanford-university/hgblhsox

- Weight tying between input embedding and LM head.
- Wider/deeper architecture: d_model=1024, 10 layers, 16 heads, context length=512, batch_size=128
- Muon^2 optimizer (variant of Muon with second moment orthogonalization: https://arxiv.org/pdf/2604.09967) for everything except for embeddings/norms (which use AdamW).
- `torch.compile`, bfloat16 autocast, TF32 matmuls
- Final loss 3.4451