### PR TITLE
Add Sara Kothari submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jiaxin Fang | 3.32098 | https://api.wandb.ai/links/jiaxinf-stanford-university/gm6mft4d | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |
-| Sara Kothari | 3.36327 | https://api.wandb.ai/links/sarako-stanford-university/iop3e8la | |
+| Sara Kothari | 3.36327 | https://api.wandb.ai/links/sarako-stanford-university/iop3e8la  | |
 | Tushar Dalmia | 3.36392 | https://api.wandb.ai/links/tdalmia-stanford-university/xxqbg3y0 | |
 | Javier Nieto   |          3.37   | https://api.wandb.ai/links/jgnieto-stanford-university/rvnadego | |
 | Tushar Aggarwal | 3.37708 | https://api.wandb.ai/links/tushar56/ogqjgcsl | |

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jiaxin Fang | 3.32098 | https://api.wandb.ai/links/jiaxinf-stanford-university/gm6mft4d | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |
+| Sara Kothari | 3.36327 | https://api.wandb.ai/links/sarako-stanford-university/iop3e8la | |
 | Tushar Dalmia | 3.36392 | https://api.wandb.ai/links/tdalmia-stanford-university/xxqbg3y0 | |
 | Javier Nieto   |          3.37   | https://api.wandb.ai/links/jgnieto-stanford-university/rvnadego | |
 | Tushar Aggarwal | 3.37708 | https://api.wandb.ai/links/tushar56/ogqjgcsl | |
@@ -53,7 +54,6 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
 | Asanshay Gupta        |          3.4451 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
 | Jiaming Shen | 3.4462 | https://api.wandb.ai/links/shenjm-stanford-university/nan5mxa8 | |
-| Sara Kothari | 3.48589 | https://api.wandb.ai/links/sarako-stanford-university/zxh58oa8 | |
 | Yuheng Wu | 3.56 | [Validation loss curve](images/yuhengwu.png) | |
 | Naveen Kannan | 3.5763 | [loss](./images/kannan.png) | |
 | Subha Vadlamannati | 3.58 | https://api.wandb.ai/links/subhavee2/5t7klnea |


### PR DESCRIPTION
Final validation loss: 3.36327

Learning curve: https://api.wandb.ai/links/sarako-stanford-university/iop3e8la

What I did:
1. Compared to the baseline configuration, I increased model depth (4 to 8 layers),
halved the batch size (256 to 128), and tuned the learning rate schedule (peak LR,
warmup, and decay parameters).
2. I also used "torch.set_float32_matmul_precision('high')". This led to a 3.5x speedup.
3. I used torch.compile
4. I tied the weights of the input and output embeddings together
5. I changed d_model to 768 and d_ff to 2048