### PR TITLE
Gorn (Nattaput) Namchittai Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Luisa Shimabucoro | 3.406 | https://api.wandb.ai/links/hashimoto-group/jr1f6dga | |
 | James Chen | 3.408 | https://api.wandb.ai/links/apple314/midc5m5v | |
 | Aniket Gupta        |          3.41563 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
+| Gorn (Nattaput) Namchittai |          3.4348  | https://api.wandb.ai/links/gorn41-stanford-university/jhwu57vq | |
 | Asanshay Gupta        |          3.4451 | https://api.wandb.ai/links/aniketgupta-stanford-university/jszkfzky | |
 | Jiaming Shen | 3.4462 | https://api.wandb.ai/links/shenjm-stanford-university/nan5mxa8 | |
 | Alex Bloom | 3.4625 | https://api.wandb.ai/links/alexpeterbloom-stanford-university/ni7vw60x | |


### PR DESCRIPTION
final val loss is 3.4348. 

link to val loss plot: https://api.wandb.ai/links/gorn41-stanford-university/jhwu57vq 

description of what I did: torch compile + lr sweep (the one used in best run is schedule lr max is 0.005 and lr min is 0.0005 with schedule dependent on wall clock time (300 seconds warmup)) + batch size sweep (the one used in best run is 128) + 8 layers + 12 heads + used torch.set_float32_matmul_precision(high) + weight decay of 0.15 +  increased d_model to 768 and d-ff to 2048