### PR TITLE
Add Aayush Gupta submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 
 | Name           | Validation Loss | Link | Verification status (leave empty) |
 | :------------- | --------------: | ---: | --------------------------------: |
-| Aayush Gupta    | 3.1701          | https://api.wandb.ai/links/aayushg55/m48845t9 |
+| Aayush Gupta    | 3.1701          | https://api.wandb.ai/links/aayushg55/m48845t9 | |
 | Haoyue Xiao    | 3.1828          | https://api.wandb.ai/links/bill-xiao-stanford-university/w7sjmi5g | |
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 
 | Name           | Validation Loss | Link | Verification status (leave empty) |
 | :------------- | --------------: | ---: | --------------------------------: |
+| Aayush Gupta    | 3.1701          | https://api.wandb.ai/links/aayushg55/m48845t9 |
 | Haoyue Xiao    | 3.1828          | https://api.wandb.ai/links/bill-xiao-stanford-university/w7sjmi5g | |
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 


### PR DESCRIPTION
Final Val Loss: 3.17
https://api.wandb.ai/links/aayushg55/m48845t9

Changes made:

Architecture:
- depth: 12
- d_model: 1024
- FFN: d_ff: 4096 with a leaky ReLU^2 activation
- context_length: 512
- zero init the LM output head

Hyperparameters/Optimizer:
- LR: max of 2e-3, min of 2e-4
- batch_size: 256
- 500 steps linear warmup, cosine decay rest (~7500 steps)
- weight decay: 0.1
- AdamW betas (0.9, 0.95) (used on 1D params)
- "adaptive" Muon (NorMuon) w/ Polars Express orthogonalization 

Performance:
- Wrapper dataset using torch DataLoader for async dataloading with prefetch and non-blocking pinned memory transfers
- torch.compile (default)
- bf16 autocast