### PR TITLE
Add Advay Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jason Meng | 4.13 | https://api.wandb.ai/links/jiemeng-stanford-university/mx5r6f5c| |
 | naive baseline |            5.00 |      |                          Verified |
 
+
+<details markdown="1">
+<summary>Stanford global leaderboard (Spring 2026) - 0.75 B200 hours</summary>
+  
+| Name           | Validation Loss | Link | Verification status (leave empty) |
+| :------------- | --------------: | ---: | --------------------------------: |
+| Advay Pal    | 3.18796          | https://api.wandb.ai/links/advaypal-stanford-university/mkwv67bo | |
+
+</details>
+
+  
 <details markdown="1">
 <summary>Stanford class leaderboard (Spring 2025) - 1.5 H100 hours</summary>
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
   
 | Name           | Validation Loss | Link | Verification status (leave empty) |
 | :------------- | --------------: | ---: | --------------------------------: |
-| Advay Pal    | 3.18796          | https://api.wandb.ai/links/advaypal-stanford-university/mkwv67bo | |
+| Advay Pal    | 3.18          | https://api.wandb.ai/links/advaypal-stanford-university/mkwv67bo | |
 
 </details>
 


### PR DESCRIPTION
Added to global leaderboard as not formally enrolled in class. Invited `marcelroed` to repo. Context length 512. Val loss is logged in the graph for a single batch, but the final val loss is computed over the entire dataset.

Implemented
- weight tying
- muon for 2d weights with adamw for non 2d weights
- torch.amp
- torch.compile
- lr tuning
- qk norm
- larger model with param count based on chinchilla paper