### PR TITLE
Add Ravenor Davion leaderboard result

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Haoyue Xiao    | 3.1828          | https://api.wandb.ai/links/bill-xiao-stanford-university/w7sjmi5g | |
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
+| Ravenor Davion | 3.21173 | https://wandb.ai/rdavion-stanford/cs336-owt/reports/CS336-A1-Leaderboard-Submission-rdavion--VmlldzoxNjU4NDQzMg | |
 | Iddah Mlauzi | 3.21391 | https://api.wandb.ai/links/iddah/1ssym3ru | |
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
 | Daniel Lee | 3.2629 | https://api.wandb.ai/links/daniel-lee-ml/esat0gwl | |


### PR DESCRIPTION
Final validation loss: 3.21173

  Learning curve: https://wandb.ai/rdavion-stanford/cs336-owt/reports/CS336-A1-Leaderboard-Submission-rdavion--VmlldzoxNjU4NDQzMg

  Description:
  weight tying, Muon, bf16 autocast, torch.compile, tuned hyperparameters