### PR TITLE
jonasds submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Tanush Talati | 3.2016 | https://api.wandb.ai/links/ttalati-stanford-university/hzi1nxpq | | 
 | Keshav Patel Keval | 3.20313 | https://api.wandb.ai/links/keshavpatel564-stanford-university/0mxcgf55 | | 
 | Iddah Mlauzi | 3.21391 | https://api.wandb.ai/links/iddah/1ssym3ru | |
+| Jonas De Schouwer | 3.22656 | https://api.wandb.ai/links/jonasdeschouwer-university-of-oxford/l9sohwly | |
 | Max Liu        |          3.2266 | https://api.wandb.ai/links/maxliu01-stanford-university/4ml64dr6 | |
 | Daniel Lee | 3.2629 | https://api.wandb.ai/links/daniel-lee-ml/esat0gwl | |
 | Alexandra Kim | 3.266 | https://api.wandb.ai/links/alexandrasuriya-ml/1nybxa71 | |


### PR DESCRIPTION
Final val loss: 3.226

Config:
- n_layers = 6
- d_model = 1024
- d_ff = 1344
- n_heads = 16
- SwiGLU FFN
- LR Muon params: 2e-2
- LR Embeddings: 2e-3
- LR Scalars: 1e-2

Fancier tricks I did:
- (Compiled) Muon optimizer
- Weight tying
- Tuned LR separately for main (Muon) params, scalars, and embeddings
- U-net like architecture that adds residual connections from layer i to layer L-1-i

Things I tried but that did not work out:
- Fused LM-head + cross-entropy kernel; fused across fwd + bwd (due to combination of skill & time issue)
- Learnable value embeddings
- Bayesian HP tuning (too cumbersome, seemed low ROI)



Definitely seems that systems optimizations could have saved at least 20% of my time. Given how much my loss is still going down at the end, that would matter a lot.