### PR TITLE
josh leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jack Le | 3.727 | https://api.wandb.ai/links/jackle3-stanford-university/ih8c149i | | 
 | Andy Ouyang | 3.7707 | https://api.wandb.ai/links/andyou-stanford-university/sf7em5l2 | |
 | Yanzhen Shen | 3.8245 | [Validation loss curve](images/yanzhen_shen_learning_curve.png) | |
+| Josh Sanyal | 3.859 | https://api.wandb.ai/links/jsanyal-stanford-university/ce5za1n7 | |
 | Silin Du | 3.89 | https://api.wandb.ai/links/silindd3-stanford-university/qwlgxrea | |
 | James Cheng | 3.89 | https://wandb.ai/jzcheng-stanford-university/cs336-assignment1?nw=nwuserjzcheng | |
 | Karthik Vetrivel | 3.9011 | https://api.wandb.ai/links/kvetriv/2qsjtsvi | |


### PR DESCRIPTION
Final model: validation loss = 3.859, train loss = 3.804

Description: I used most of the recommended hyperparameters with a lr=1e-3, batch_size=32, and context_length = 512. The cosine scheduler had a warmup during the first 2% of training and min_lr = 10% * lr. Most of the experimentation focused on lr (experiments below) and then using the results from the batch_size experiments from TinyStories. 