### PR TITLE
Add Kesavan Ramakrishnan Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jiaming Shen | 3.4462 | https://api.wandb.ai/links/shenjm-stanford-university/nan5mxa8 | |
 | Alex Bloom | 3.4625 | https://api.wandb.ai/links/alexpeterbloom-stanford-university/ni7vw60x | |
 | Insop Song | 3.546 | https://api.wandb.ai/links/insop-song2/34j0x6dk | |
+| Kesavan Ramakrishnan | 3.552 | https://api.wandb.ai/links/kesavanramakrishnan/11kdybm3 | |
 | Yuheng Wu | 3.56 | [Validation loss curve](images/yuhengwu.png) | |
 | Naveen Kannan | 3.5763 | [loss](./images/kannan.png) | |
 | Subha Vadlamannati | 3.58 | https://api.wandb.ai/links/subhavee2/5t7klnea |


### PR DESCRIPTION
Val Loss: 3.552, modifications I made: XSA (exclusive self attention), used bf16 via torch.autocast for the activations + gradient, made model deeper to 6 layers with d_model 768 and d_ff = 2048, weight tying between input embedding and output projection.