### PR TITLE
Add Juntong Shi's validation loss entry to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jiaxin Fang | 3.32098 | https://api.wandb.ai/links/jiaxinf-stanford-university/gm6mft4d | |
 | Tim Chen | 3.335 | https://wandb.ai/chentim-sh-stanford-university/cs336-assignment1/reports/valid_loss-26-04-15-15-36-54---VmlldzoxNjU0NTU4Ng | |
 | Eric Chen| 3.33875 | https://api.wandb.ai/links/3ricme-Stanford%20University/cimht73a | |
+| Juntong Shi| 3.34792 | https://api.wandb.ai/links/shisteve/371nx7zv | |
 | Sara Kothari | 3.36327 | https://api.wandb.ai/links/sarako-stanford-university/iop3e8la  | |
 | Tushar Dalmia | 3.36392 | https://api.wandb.ai/links/tdalmia-stanford-university/xxqbg3y0 | |
 | Javier Nieto   |          3.37   | https://api.wandb.ai/links/jgnieto-stanford-university/rvnadego | |


### PR DESCRIPTION
- mixed precision training (use bf16 for computation)
- Train on extended context
    - train with context_length=1024, evaluate on context_length=512
- Scaling
    - num_layers: 12
    - d_model: 768
    - num_heads: 12
    - d_ff: 2048
- Careful tuning of lr schedule
    - lr: 3e-3
    - cosine annealing finishes at about 90% of training