### PR TITLE
Bodo Wirth Leaderboard Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Stanford class leaderboard (Spring 2026) - 0.75 B200 hours
 | Jack Le | 3.727 | https://api.wandb.ai/links/jackle3-stanford-university/ih8c149i | | 
 | Andy Ouyang | 3.7707 | https://api.wandb.ai/links/andyou-stanford-university/sf7em5l2 | |
 | Yanzhen Shen | 3.8245 | [Validation loss curve](images/yanzhen_shen_learning_curve.png) | |
+| Bodo Wirth |3.8382 |https://api.wandb.ai/links/bodow-stanford-university/nbix2hng | |
 | Silin Du | 3.89 | https://api.wandb.ai/links/silindd3-stanford-university/qwlgxrea | |
 | James Cheng | 3.89 | https://wandb.ai/jzcheng-stanford-university/cs336-assignment1?nw=nwuserjzcheng | |
 | Karthik Vetrivel | 3.9011 | https://api.wandb.ai/links/kvetriv/2qsjtsvi | |


### PR DESCRIPTION
Val Loss: 3.8382
Mainly the base model but with context length 512, batch 128, lr 5e-3 and warmup 140 steps.